### PR TITLE
return test(6, 2000, false, 'even'); will always result in error message

### DIFF
--- a/part9/referee.js
+++ b/part9/referee.js
@@ -7,7 +7,7 @@ test('test', 0, false, 'error')
 })
 
 .then(function() {
-    return test(6, 2000, false, 'even');
+    return test(6, 2000, true, 'even');
 })
 
 .then(function() {


### PR DESCRIPTION
return test(6, 2000, false, 'even') will result in resolved false status regardless whether the `job` function actually worked or not, it's a bug.